### PR TITLE
fix: added missing response schemas + other improvements

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -115,8 +115,9 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
+  termsOfService: https://ossindex.sonatype.org/tos
   title: Sonatype OSS Index
-  version: '2024.320'
+  version: '2024.323'
 openapi: 3.0.1
 paths:
   /api/v3/authorized/component-report:
@@ -133,7 +134,13 @@ paths:
         required: false
       responses:
         '200':
-          content: {}
+          content: &id001
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentReport'
+            application/vnd.ossindex.component-report-request.v1+json:
+              schema:
+                $ref: '#/components/schemas/ComponentReport'
           description: Vulnerability report for components
         '400':
           content: {}
@@ -162,7 +169,7 @@ paths:
         required: false
       responses:
         '200':
-          content: {}
+          content: *id001
           description: Vulnerability report for components
         '400':
           content: {}
@@ -191,7 +198,7 @@ paths:
       tags:
       - Version
 servers:
-- url: /
+- url: https://ossindex.sonatype.org
 tags:
 - name: Component vulnerability reports
 - name: Version

--- a/update-spec.py
+++ b/update-spec.py
@@ -58,8 +58,32 @@ json_spec['info'] = {
         'name': 'Apache 2.0',
         'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
     },
+    'termsOfService': 'https://ossindex.sonatype.org/tos',
     'version': OSS_INDEX_API_VERSION
 }
+
+print('Injecting correct `servers`')
+json_spec['servers'] = [
+    {
+        'url': 'https://ossindex.sonatype.org'
+    }
+]
+
+# Fix Response Schemas
+vuln_response = {
+    'application/json': {
+        'schema': {
+            '$ref': '#/components/schemas/ComponentReport'
+        }
+    },
+    'application/vnd.ossindex.component-report-request.v1+json': {
+        'schema': {
+            '$ref': '#/components/schemas/ComponentReport'
+        }
+    }
+}
+json_spec['paths']['/api/v3/component-report']['post']['responses']['200']['content'] = vuln_response
+json_spec['paths']['/api/v3/authorized/component-report']['post']['responses']['200']['content'] = vuln_response
 
 # Add `securitySchemes` under `components`
 if 'components' in json_spec and 'securitySchemes' in json_spec['components'] and 'basicAuth' not in \


### PR DESCRIPTION
- Added missing response schemas for two main API calls
- Defined `termsOfService` in `info`
- Injected default `server`